### PR TITLE
Fixed incoming data stream and support for socket reconnect

### DIFF
--- a/bin/groupsocketlisten
+++ b/bin/groupsocketlisten
@@ -21,6 +21,10 @@ function groupsocketlisten(opts, callback) {
 
   });
 
+  einbdcon.on('close', function () {
+    //restart...
+    setTimeout(function () { groupsocketlisten(opts, callback); }, 100);
+  });
 }
 
 var host = process.argv[2];

--- a/bin/groupsocketlisten
+++ b/bin/groupsocketlisten
@@ -21,7 +21,7 @@ function groupsocketlisten(opts, callback) {
 
   });
 
-  einbdcon.on('close', function () {
+  conn.on('close', function () {
     //restart...
     setTimeout(function () { groupsocketlisten(opts, callback); }, 100);
   });

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -35,6 +35,7 @@ Connection.prototype.socketRemote = function(opts, callback) {
   self.socket = net.connect(opts, callback);
   self.socket.on('error', callback);
   self.socket.on('error', self.onError);
+  self.socket.on('close', function () { self.emit('close') });
 };
 
 /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -16,19 +16,17 @@ function Parser(socket, options) {
 
   this.decoder = new Decoder();
   this._source = socket;
-  this._inPackage = false;
-  this._len = null;
-  this._telegram = [];
+  this._inputBuffer = new Buffer(0);
   
   var self = this;
   // hit source end
   this._source.on('end', function() {
-    self.push(null);
+
   });
 
-  // hit source readable
-  this._source.on('readable', function() {
-    self.read(0);
+  // get data
+  this._source.on('data', function(data) {
+    self.onData(data);
   });
 
 }
@@ -101,45 +99,43 @@ Parser.prototype.parseTelegram = function(telegram) {
 };
 
 /**
- * fetch data from socket
+ * data received from socket
  */
-Parser.prototype._read = function() {
-  var chunk = this._source.read();
+Parser.prototype.onData = function(chunk) {
 
   // no data received
   if(chunk === null) {
-    return this.push('');
+    return ;
   }
-  
-  // telegram len received
-  if(!this._inPackage && chunk.length >= 2) {
-    this._len = chunk[1];
-    this._inPackage = true;
-  }
-
-  // store chunk
-  this._telegram.push(chunk);
-
-  // make buffer to one telegram
-  var data = Buffer.concat(this._telegram);
-  var telegram = data.slice(0, this._len+2);
-  // check telegram is complety received
-  if(this._len+2 === telegram.length ) {
-    this._telegram = this._telegram.slice(0, this._len+2);
     
-    if(this._len > 2) {
+  // store chunk
+  this._inputBuffer = Buffer.concat([this._inputBuffer, chunk]);
+    
+  while (true) {
+    // check if at least length header is here
+    if (this._inputBuffer.length < 2) {
+      return;
+    }
+
+    var packetlen = this._inputBuffer[1] + 2;
+    if (packetlen > this._inputBuffer.length) {
+      //not enough data
+      return;
+    }
+
+    //what kind of packet have we got...
+    if (packetlen === 4) {
+      //confirm mag
+    } else if (packetlen === 5) {
+      //opengroupsocket
+    } else if (packetlen >= 6) {
+      // we have at least one complete package
+      var telegram = new Buffer(this._inputBuffer.slice(0, packetlen));
       // emit event
       this.parseTelegram(telegram);
     }
-
-    // housekeeping for next telegram
-    this._inPackage = false;
-    this._len = null;
-    this._telegram = [];
+    this._inputBuffer = new Buffer(this._inputBuffer.slice(packetlen));
   }
-
-  // hit stream to be readable again
-  return this.push('');
 };
 
 module.exports = Parser;


### PR DESCRIPTION
Hi,

there is one impreovement here:
emit the close event from the socket to allow detection of a dropped connectiion (e.g. eibd restarted).
The groupsocketlisten example now uses it.

There is also a fix for the parser:
It did not correctly scan the input stream for messages, it just took the first message in the read data stream.
The parser can now handle messages:
-coming fast (more than one message coming in one read request)
-fragmented (only a partial message coming in one read request)

I how you will accept my pull request.