### PR TITLE
Added 'UNKN' Datatype for unknown data in events (second try)

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -178,11 +178,12 @@ Decoder.prototype.decodeDPT16 = function(buffer) {
 Decoder.prototype.decode = function(len, data, callback) {
 
   var err = null;
-  var type = 'DPT1';
+  var type = 'UNKN';
   var value = null;
 
   // eis 1 / dpt 1.xxx
   if(len === 8) {
+    type = 'DPT1';
     value = data-64;
     if(value > 1) {
       value = value-64;
@@ -210,6 +211,11 @@ Decoder.prototype.decode = function(len, data, callback) {
     else {
       err = new Error('Invalid data len for DPT9');
     }
+  }
+
+  //If still unkown take the raw Buffer
+  if(type === 'UNKN') {
+    value = data;
   }
 
   if(callback) {

--- a/test/decoder.test.js
+++ b/test/decoder.test.js
@@ -104,6 +104,39 @@ describe('Decoder', function() {
         assert.equal(Math.round(value * 100) / 100, -5.08);
       });
     });
-    
+  });
+  describe('UNKN', function() {
+    it('should decode DPT14 float value', function() {
+      var buf = new Buffer(4);
+      buf.writeUInt8(0x3e, 0);
+      buf.writeUInt8(0x9a, 1);
+      buf.writeUInt8(0x1c, 2);
+      buf.writeUInt8(0xac, 3);
+      enc.decode(12, buf, function(err, type, value) {
+        assert.equal(err, null);
+        assert.equal(type, 'UNKN');
+        var decoded = enc.decodeDPT14(value);
+        assert.equal(Math.round(decoded * 1000) / 1000, 0.301);
+      });
+    });
+    it('should decode DPT13 32bit integer value', function() {
+      var buf = new Buffer(4);
+      buf.writeInt32BE(0x6eadbeef);
+      enc.decode(12, buf, function(err, type, value) {
+        assert.equal(err, null);
+        assert.equal(type, 'UNKN');
+        var decoded = enc.decodeDPT13(value);
+        assert.equal(decoded, 0x6eadbeef);
+      });
+    });
+    it('should decode DPT16.002 Character String', function() {
+      var buf = Buffer.from('Hi buffer!!', 'latin1');
+      enc.decode(8 + buf.length, buf, function(err, type, value) {
+        assert.equal(err, null);
+        assert.equal(type, 'UNKN');
+        var decoded = value.toString('latin1');
+        assert.equal(decoded, 'Hi buffer!!');
+      });
+    });
   });
 });

--- a/test/decoder.test.js
+++ b/test/decoder.test.js
@@ -130,11 +130,11 @@ describe('Decoder', function() {
       });
     });
     it('should decode DPT16.002 Character String', function() {
-      var buf = Buffer.from('Hi buffer!!', 'latin1');
+      var buf = Buffer.from('Hi buffer!!');
       enc.decode(8 + buf.length, buf, function(err, type, value) {
         assert.equal(err, null);
         assert.equal(type, 'UNKN');
-        var decoded = value.toString('latin1');
+        var decoded = value.toString();
         assert.equal(decoded, 'Hi buffer!!');
       });
     });

--- a/test/decoder.test.js
+++ b/test/decoder.test.js
@@ -121,7 +121,7 @@ describe('Decoder', function() {
     });
     it('should decode DPT13 32bit integer value', function() {
       var buf = new Buffer(4);
-      buf.writeInt32BE(0x6eadbeef);
+      buf.writeInt32BE(0x6eadbeef, 0);
       enc.decode(12, buf, function(err, type, value) {
         assert.equal(err, null);
         assert.equal(type, 'UNKN');

--- a/test/decoder.test.js
+++ b/test/decoder.test.js
@@ -129,14 +129,5 @@ describe('Decoder', function() {
         assert.equal(decoded, 0x6eadbeef);
       });
     });
-    it('should decode DPT16.002 Character String', function() {
-      var buf = Buffer.from('Hi buffer!!');
-      enc.decode(8 + buf.length, buf, function(err, type, value) {
-        assert.equal(err, null);
-        assert.equal(type, 'UNKN');
-        var decoded = value.toString();
-        assert.equal(decoded, 'Hi buffer!!');
-      });
-    });
   });
 });


### PR DESCRIPTION
Hi,
The events of the decoder do not contain any data, if the DPT cannot be determined by length.

I have seen another pull request concerning the same issue, but I think I have the better solution.
Just pass the raw data , if the DPT cannot be determined.

Thanks for accepting by pull request.