### PR TITLE
tools.js: allow 16bit addresses

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -35,7 +35,7 @@ module.exports.str2addr = function(str) {
 module.exports.addr2str = function(adr, ga) {
   var str = '';
   if(ga === true) {
-    var a = (adr>>11)&0xf;
+    var a = (adr>>11)&0x1f; // allow 16bit addresses using 5 bits for the first address part
     var b = (adr>>8)&0x7;
     var c = (adr & 0xff);
     str = a+'/'+b+'/'+c;


### PR DESCRIPTION
allow 16bit addresses using **5 bits** for the first address part for incoming telegrams.  
Change: mask &0xf to &0x1f