### PR TITLE
Raw telegram event

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,4 +7,4 @@ exports.Connection = Connection;
 exports.Parser = Parser;
 exports.createMessage = createMessage;
 exports.str2addr = tools.str2addr;
-exports.addr2str = tools.adr2str;
+exports.addr2str = tools.addr2str;

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -76,7 +76,10 @@ Parser.prototype.parseTelegram = function(telegram) {
     if(len > 8) {
       val = telegram.slice(10, telegram.length);
     }
-
+    
+    // emit raw telegram event, pass the addresses and the buffer, no DPT guessing, copy of data buffer
+    self.emit('telegram', event, tools.addr2str(src, false), tools.addr2str(dest, true), Buffer.from(val));
+    
     self.decoder.decode(len, val, function(err, type, value) {
 
       // emit action event

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -71,14 +71,29 @@ Parser.prototype.parseTelegram = function(telegram) {
     
     // value
     var val = null;
-
-    val = telegram[telegram.length-1];
-    if(len > 8) {
+    var valbuffer;
+    if (len<=8) {
+      val = telegram[telegram.length-1];
+      if (Buffer.from) {
+        valbuffer = Buffer.from(val);  
+      } else {
+        // ancient nodejs (<5.1)
+    	valbuffer = new Buffer(1); // this is deprecated as of node 6.0.0 and must only be used in older node
+    	valbuffer[0] = val;
+      }
+    } else { //if(len > 8) 
       val = telegram.slice(10, telegram.length);
+      if (Buffer.from) {
+          valbuffer = Buffer.from(val);  
+        } else {
+          // ancient nodejs (<5.1)
+      	valbuffer = new Buffer(val.length); // this is deprecated as of node 6.0.0 and must only be used in older node
+      	val.copy(valbuffer); // copies the data buffer to a new location (so it's modification proof)
+        }
     }
     
     // emit raw telegram event, pass the addresses and the buffer, no DPT guessing, copy of data buffer
-    self.emit('telegram', event, tools.addr2str(src, false), tools.addr2str(dest, true), Buffer.from(val));
+    self.emit('telegram', event, tools.addr2str(src, false), tools.addr2str(dest, true), valbuffer);
     
     self.decoder.decode(len, val, function(err, type, value) {
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -78,8 +78,8 @@ Parser.prototype.parseTelegram = function(telegram) {
         valbuffer = Buffer.from(val);  
       } else {
         // ancient nodejs (<5.1)
-    	valbuffer = new Buffer(1); // this is deprecated as of node 6.0.0 and must only be used in older node
-    	valbuffer[0] = val;
+    	// val is an integer, to to pass it to Buffer we need to make it an Array of length 1
+    	valbuffer = new Buffer([val]); // this is deprecated as of node 6.0.0 and must only be used in older node
       }
     } else { //if(len > 8) 
       val = telegram.slice(10, telegram.length);
@@ -87,8 +87,8 @@ Parser.prototype.parseTelegram = function(telegram) {
           valbuffer = Buffer.from(val);  
         } else {
           // ancient nodejs (<5.1)
-      	valbuffer = new Buffer(val.length); // this is deprecated as of node 6.0.0 and must only be used in older node
-      	val.copy(valbuffer); // copies the data buffer to a new location (so it's modification proof)
+          // val is a buffer itself 
+      	  valbuffer = new Buffer(val); // this is deprecated as of node 6.0.0 and must only be used in older node
         }
     }
     

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -74,7 +74,7 @@ Parser.prototype.parseTelegram = function(telegram) {
     var valbuffer;
     if (len<=8) {
       val = telegram[telegram.length-1];
-      if (Buffer.from) {
+      if (Buffer.alloc) { // use Buffer.alloc as a means of distinction, as Buffer.from existed in node 4.4 but did not work as expected
         valbuffer = Buffer.from(val);  
       } else {
         // ancient nodejs (<5.1)
@@ -83,7 +83,7 @@ Parser.prototype.parseTelegram = function(telegram) {
       }
     } else { //if(len > 8) 
       val = telegram.slice(10, telegram.length);
-      if (Buffer.from) {
+      if (Buffer.alloc) { // see above
           valbuffer = Buffer.from(val);  
         } else {
           // ancient nodejs (<5.1)

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -3,6 +3,13 @@
 var Readable = require('stream').Readable,
     Decoder = require('./decoder'),
     tools = require('./tools');
+
+var isModernBuffer = (
+		  typeof Buffer.alloc === 'function' &&
+		  typeof Buffer.allocUnsafe === 'function' &&
+		  typeof Buffer.from === 'function'
+		);
+
 /**
  * Parser
  */
@@ -74,22 +81,10 @@ Parser.prototype.parseTelegram = function(telegram) {
     var valbuffer;
     if (len<=8) {
       val = telegram[telegram.length-1];
-      if (Buffer.alloc) { // use Buffer.alloc as a means of distinction, as Buffer.from existed in node 4.4 but did not work as expected
-        valbuffer = Buffer.from(val);  
-      } else {
-        // ancient nodejs (<5.1)
-    	// val is an integer, to to pass it to Buffer we need to make it an Array of length 1
-    	valbuffer = new Buffer([val]); // this is deprecated as of node 6.0.0 and must only be used in older node
-      }
+      valbuffer = isModernBuffer ? Buffer.from(val) : new Buffer([val]);  
     } else { //if(len > 8) 
       val = telegram.slice(10, telegram.length);
-      if (Buffer.alloc) { // see above
-          valbuffer = Buffer.from(val);  
-        } else {
-          // ancient nodejs (<5.1)
-          // val is a buffer itself 
-      	  valbuffer = new Buffer(val); // this is deprecated as of node 6.0.0 and must only be used in older node
-        }
+      valbuffer = isModernBuffer ? Buffer.from(val) : new Buffer(val);  
     }
     
     // emit raw telegram event, pass the addresses and the buffer, no DPT guessing, copy of data buffer

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 { 
 	"name": "eibd", 
-	"version": "0.3.7", 
+	"version": "0.3.8", 
 	"description": "node eibd client", 
 	"main": "./index", 
 	"repository": { 


### PR DESCRIPTION
When using an exernal decoder for telegram data, the event system could not be used fully as the data was pre-parsed by decoder.js decode() which might not have been guessing the type right (e.g. for a lot of scaled data types)

Refers to #47 