### PR TITLE
Raw telegram event - Buffer.from(value) must not use number

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -81,7 +81,7 @@ Parser.prototype.parseTelegram = function(telegram) {
     var valbuffer;
     if (len<=8) {
       val = telegram[telegram.length-1];
-      valbuffer = isModernBuffer ? Buffer.from(val) : new Buffer([val]);  
+      valbuffer = isModernBuffer ? Buffer.from([val]) : new Buffer([val]);  
     } else { //if(len > 8) 
       val = telegram.slice(10, telegram.length);
       valbuffer = isModernBuffer ? Buffer.from(val) : new Buffer(val);  


### PR DESCRIPTION
For security reasons the `Buffer.from()` does not take numbers (any more?) to initialize a new Buffer. To pass a value to a new buffer, it needs either to be a buffer itself, or an array.
Not sure how that could have slipped, but it has, apparently.