### PR TITLE
Clean the action/data bytes interpretation in parser.js

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -48,19 +48,16 @@ Parser.prototype.parseTelegram = function(telegram) {
   var dest = telegram.readUInt16BE(6);
 
   // action
-  var action = telegram.readUInt8(9);
+  var action = (telegram.readUInt8(8) & (3))*8+((telegram.readUInt8(9) & (192)) >> 6); //bytes 8 lowest 2 bits and byte 9 highest two bits are action (AND VALUE if VALUE HAS LESS THEN 7 bits !!!!)
   var event = '';
-  switch(action)  {
-    case 129:
+  switch (action) {
+    case 10:
+      event = 'memory write';
+      break;
+    case 2:
       event = 'write';
       break;
-    case 128:
-      event = 'write';
-      break;
-    case 65:
-      event = 'response';
-      break;
-    case 64:
+    case 1:
       event = 'response';
       break;
     case 0:
@@ -74,7 +71,7 @@ Parser.prototype.parseTelegram = function(telegram) {
     var val = null;
     var valbuffer;
     if (len<=8) {
-      val = telegram[telegram.length-1];
+      val = telegram[telegram.length-1] & 63; // only 6 bits for data in the mixed action/data byte
       valbuffer = Buffer.from([val]);  
     } else { //if(len > 8) 
       val = telegram.slice(10, telegram.length);


### PR DESCRIPTION
telegram bytes 8+9 were missing bit masking and shifting to make interpretation according to "KNX Grundkursunterlagen" vol 2009, page 22.

This led to strange values for DPT1 raw data (two additional bits in the value) and strange action values (should be only 0,1,2, and 10)

Discovered this while working on a backend for CometVisu using knxd + node-eibd