### PR TITLE
Fix line-endings and whitespace issues in bin-folder files

### DIFF
--- a/bin/groupread
+++ b/bin/groupread
@@ -46,9 +46,9 @@ if(!host || !port) {
 	if (host==='--socket') {
 		var opts = {path:port}; //path is hiding behind port variable from args
 	} else {
-		opts = { 
-			host: host, 
-			port: port 
+		opts = {
+			host: host,
+			port: port
 		};
 	}
 	groupread(opts, gad, function(err) {

--- a/bin/groupsend
+++ b/bin/groupsend
@@ -9,7 +9,7 @@ var eibd = require('../');
  * Send a KNX telegram with support for read/write/response messages and DPT1, DPT2, DPT3, DPT5, DPT9 data format
  * Contains functionality from groupread/groupwrite/groupswrite in one cmd line application
  *
- * Arguments: host port gad action dpt value 
+ * Arguments: host port gad action dpt value
  * host = ipadress (Ex. 127.0.0.1 - localhost - host.com)5
  * port = portnumber (Ex. 6720)
  * gad = groupnumber (Ex. 1/2/34)
@@ -17,7 +17,7 @@ var eibd = require('../');
  * dpt = data point type for write/response (Ex. DPT1, DPT2, DPT3, DPT5, DPT9)
  * value = data value for write/response (Ex. true , 23 , 12.23)
  */
-function send(opts, gad, action, dpt, value, callback) { 
+function send(opts, gad, action, dpt, value, callback) {
   var conn = new eibd.Connection();
   conn.socketRemote(opts, function(err) {
 
@@ -32,7 +32,7 @@ function send(opts, gad, action, dpt, value, callback) {
         callback(err);
         return;
       }
-      
+
       var msg = eibd.createMessage(action, dpt, parseFloat(value));
       conn.sendAPDU(msg, callback);
 
@@ -80,9 +80,9 @@ if(argumentsError) {
 	if (host==='--socket') {
 		var opts = {path:port}; //path is hiding behind port variable from args
 	} else {
-		opts = { 
-			host: host, 
-			port: port 
+		opts = {
+			host: host,
+			port: port
 		};
 	}
   send(opts, gad, action, dpt, value, function(err) {

--- a/bin/groupsocketlisten
+++ b/bin/groupsocketlisten
@@ -66,6 +66,6 @@ if(!host || !port) {
     } else {
       console.error('[ERROR] '+err);
     }
-  
+
   });
 }

--- a/bin/groupswrite
+++ b/bin/groupswrite
@@ -47,9 +47,9 @@ if(!host || !port) {
 	if (host==='--socket') {
 		var opts = {path:port}; //path is hiding behind port variable from args
 	} else {
-		opts = { 
-			host: host, 
-			port: port 
+		opts = {
+			host: host,
+			port: port
 		};
 	}
 	groupswrite(opts, gad, value, function(err) {
@@ -60,5 +60,3 @@ if(!host || !port) {
 		}
 	});
 }
-
-

--- a/bin/groupwrite
+++ b/bin/groupwrite
@@ -48,9 +48,9 @@ if(!host || !port) {
 	if (host==='--socket') {
 		var opts = {path:port}; //path is hiding behind port variable from args
 	} else {
-		opts = { 
-			host: host, 
-			port: port 
+		opts = {
+			host: host,
+			port: port
 		};
 	}
 	groupwrite(opts, gad, value, function(err) {


### PR DESCRIPTION
Currently, running the bin-files on Linux-OSs fails with `env: node\r: No such file or directory` due to CRLF encodings in most of the bin-files - see the following issue for explanation and background-info: [npm/npm#12371](https://github.com/npm/npm/issues/12371)

I also corrected some whitespace-issues as well, but still recommend to apply some modern formatting guidelines (using prettierjs et.al.) for the whole project, but this would blow the scope of this PR.

After this PR e.g. `./bin/groupread` runs successful on my (Linux-) box again.